### PR TITLE
Fix renderer to use 'summary', handle no Location case

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.11.0"
     id("org.jetbrains.kotlin.jvm") version "1.3.61"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ object Constant {
     val pluginName = "AndroidLintReporterPlugin"
     val id = "com.worker8.android_lint_reporter"
     val implementationClass = "android_lint_reporter.AndroidLintReporterPlugin"
-    val version = "1.0.1"
+    val version = "1.1.0"
     val website = "https://github.com/worker8/AndroidLintReporter"
     val displayName = "Android Lint Reporter"
     val description = "Gradle Plugin to parse, format, report Android Lint result back to Github Pull Request using Github Actions"

--- a/src/main/kotlin/android_lint_reporter/model/Location.kt
+++ b/src/main/kotlin/android_lint_reporter/model/Location.kt
@@ -1,3 +1,3 @@
 package android_lint_reporter.model
 
-data class Location(val file: String, val line: String, val column: String)
+data class Location(val file: String, val line: String = "", val column: String = "")

--- a/src/main/kotlin/android_lint_reporter/parser/Renderer.kt
+++ b/src/main/kotlin/android_lint_reporter/parser/Renderer.kt
@@ -23,14 +23,19 @@ object Renderer {
 
         val currentPath = File("").getAbsolutePath()
         issues.warningList.forEach { issue ->
-            warningBody += """| <details><summary>${issue.location.file.replace(
-                "${currentPath}/",
+            val locationString = if (issue.location.line.isBlank() && issue.location.column.isBlank()) {
                 ""
-            )} **L${issue.location.line}:${issue.location.column}**</summary> `${issue.errorLine1}`</details> | <details> <summary>${issue.message}</summary> <br>_${issue.explanation.removeNewLine()}_</details>|\n"""
+            } else {
+                "**L${issue.location.line}:${issue.location.column} **"
+            }
+            warningBody += """| <details><summary>${issue.location.file.replace(
+                    "${currentPath}/",
+                    ""
+            )} ${locationString}</summary> `${issue.errorLine1}`</details> | <details> <summary>${issue.summary}</summary> <br>_${issue.explanation.removeNewLine()}_</details>|\n"""
         }
 
         warningBody =
-            warningBody.replace("XXwarning_numberXX", issues.warningList.count().toString())
+                warningBody.replace("XXwarning_numberXX", issues.warningList.count().toString())
         errorBody = errorBody.replace("XXerror_numberXX", issues.errorList.count().toString())
         errorBody += "</details>"
         var bodyString = ""


### PR DESCRIPTION
Show `summary` instead of `message`. `message` contains many formatting that might break defail-summary block in github markdown.

`Location` will not always be available, so an if statement is added to handle this case.